### PR TITLE
Add previous name to coins

### DIFF
--- a/db/migrate/20180406091445_add_previous_name_to_coins.rb
+++ b/db/migrate/20180406091445_add_previous_name_to_coins.rb
@@ -1,0 +1,5 @@
+class AddPreviousNameToCoins < ActiveRecord::Migration[5.1]
+  def change
+    add_column :coins, :previous_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180406014547) do
+ActiveRecord::Schema.define(version: 20180406091445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_stat_statements"
 
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
@@ -177,6 +176,7 @@ ActiveRecord::Schema.define(version: 20180406014547) do
     t.string "blockchain_tech"
     t.string "token_type"
     t.jsonb "exchanges", array: true
+    t.string "previous_name"
     t.index ["category"], name: "index_coins_on_category"
     t.index ["market_cap"], name: "index_coins_on_market_cap", using: :gin
     t.index ["price"], name: "index_coins_on_price", using: :gin


### PR DESCRIPTION
PR to add `previous_name` field to `coins` to handle name changes.