### PR TITLE
[PLA-199] Fix coin rank

### DIFF
--- a/app/helpers/coins_helper.rb
+++ b/app/helpers/coins_helper.rb
@@ -39,4 +39,7 @@ module CoinsHelper
     }
   end
 
+  def paged_index(page, page_size, index)
+    ((page - 1) * page_size) + index + 1
+  end
 end

--- a/app/services/coin_market_cap_service.rb
+++ b/app/services/coin_market_cap_service.rb
@@ -1,0 +1,40 @@
+class CoinMarketCapService
+  def ticker_update
+    @failed_updates = []
+    data = load_cmc_ticker_data
+    coins(data).each do |coin|
+      identifier = coin["identifier"]
+      update_coin(identifier, coin)
+    end
+    pp @failed_updates
+  end
+
+  private
+
+  def update_coin(identifier, data)
+    coin = Coin.find_by(slug: identifier)
+    @failed_updates << identifier and return if coin.nil?
+    coin.update!(
+      ranking: data["position"],
+      market_cap: data["marketCap"],
+      price: data["price"],
+      volume24: data["volume24"],
+      available_supply: data["availableSupply"],
+      change24h: data["change24h"],
+      change1h: data["change1h"],
+      change7d: data["change7d"],
+      last_synced: data["timestamp"],
+      ico_status: 'listed'
+    )
+  end
+
+  def coins(data)
+    data["markets"]
+  end
+
+  def load_cmc_ticker_data
+    ticker_url = "http://coinmarketcap.northpole.ro/ticker.json?identifier=&version=v8"
+    response = HTTParty.get(ticker_url)
+    JSON.parse(response.body)
+  end
+end

--- a/app/services/coin_market_cap_service.rb
+++ b/app/services/coin_market_cap_service.rb
@@ -6,14 +6,17 @@ class CoinMarketCapService
       identifier = coin["identifier"]
       update_coin(identifier, coin)
     end
-    pp @failed_updates
+    @failed_updates.sort!{|x, y| x[:ranking] <=> y[:ranking]}
+    @failed_updates.each do |update|
+      Rails.logger.info "MISSING COIN: Rank #{update[:ranking]} #{update[:identifier]} coin from CMC is missing from the `coins` table."
+    end
   end
 
   private
 
   def update_coin(identifier, data)
     coin = Coin.find_by(slug: identifier)
-    @failed_updates << identifier and return if coin.nil?
+    @failed_updates << {identifier: identifier, ranking: data["position"].to_i} and return if coin.nil?
     coin.update!(
       ranking: data["position"],
       market_cap: data["marketCap"],

--- a/app/views/coins/index.slim
+++ b/app/views/coins/index.slim
@@ -17,10 +17,10 @@
             - if current_user
               th.reveal-m
         tbody
-          - @coins.each do |coin|
+          - @coins.each_with_index do |coin, idx|
             tr
               td.pr0
-                = coin.ranking
+                = paged_index(@coins.current_page, @coins.limit_value, idx)
               td
                 .flex.items-center
                   = image_tag coin.image_url, class: 'w2e mr2', alt: coin.name if coin.image_url.present?

--- a/lib/tasks/coinmarketcap.rake
+++ b/lib/tasks/coinmarketcap.rake
@@ -5,32 +5,7 @@ namespace :coinmarketcap do
     # Direct ticker access
     desc "10min ticker price update"
     task :ticker_update => :environment do
-      Coin.where.not(slug: '').find_each do |coin|
-        puts coin.slug
-        ticker_url = "http://coinmarketcap.northpole.ro/ticker.json?identifier=#{coin.slug}&version=v8"
-        begin
-          response = HTTParty.get(ticker_url)
-          contents = JSON.parse(response.body)
-
-          next if contents["markets"].blank?
-
-          data = contents["markets"].first
-          coin.update(
-            ranking: data["position"],
-            market_cap: data["marketCap"],
-            price: data["price"],
-            volume24: data["volume24"],
-            available_supply: data["availableSupply"],
-            change24h: data["change24h"],
-            change1h: data["change1h"],
-            change7d: data["change7d"],
-            last_synced: data["timestamp"],
-            ico_status: 'listed'
-          )
-        rescue => e
-          puts e.message
-        end
-      end
+      CoinMarketCapService.new.ticker_update
     end
 
     # Grab history but only keep most recent day.


### PR DESCRIPTION
This PR is intended to fix the coin rank value on the coins page which has duplicate numbers, and misses values.

There are two fixes:

- The `ticker_update` rake task has been changed to make it more efficient (so we should hopefully have fewer failures, and better data)
- The ranking uses the row index rather than cached `position` value