### PR TITLE
Add is_machine_tagged to NewsCoinMentions #697593097642219

### DIFF
--- a/db/migrate/20180605005836_add_is_machine_tagged_to_news_coin_mentions.rb
+++ b/db/migrate/20180605005836_add_is_machine_tagged_to_news_coin_mentions.rb
@@ -1,0 +1,6 @@
+class AddIsMachineTaggedToNewsCoinMentions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :news_coin_mentions, :is_machine_tagged, :boolean, default: false
+    add_index :news_coin_mentions, :is_machine_tagged
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180604063450) do
+ActiveRecord::Schema.define(version: 20180605005836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -281,7 +281,9 @@ ActiveRecord::Schema.define(version: 20180604063450) do
   create_table "news_coin_mentions", force: :cascade do |t|
     t.bigint "coin_id"
     t.bigint "news_item_id"
+    t.boolean "is_machine_tagged", default: false
     t.index ["coin_id"], name: "index_news_coin_mentions_on_coin_id"
+    t.index ["is_machine_tagged"], name: "index_news_coin_mentions_on_is_machine_tagged"
     t.index ["news_item_id"], name: "index_news_coin_mentions_on_news_item_id"
   end
 


### PR DESCRIPTION
https://app.asana.com/0/687789576763635/697593097642219

This pull request allows Data Science team members to run machine tagging and distinguish between human vs machine tagged NewsCoinMentions.