### PR TITLE
Only run NewsItem#notify_news_tagger after DB commit

### DIFF
--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -15,7 +15,7 @@ class NewsItem < ApplicationRecord
 
   alias_method :categories, :news_categories
 
-  after_create :notify_news_tagger
+  after_create_commit :notify_news_tagger
 
   def coin_link_data
     coins.map{ |c| c.as_json(only: [:symbol, :slug] ) }
@@ -38,6 +38,6 @@ class NewsItem < ApplicationRecord
     return unless news_tagger_endpoint.present?
 
     auth = {username: ENV.fetch('NEWS_TAGGER_BASIC_AUTH_USERNAME'), password: ENV.fetch('NEWS_TAGGER_BASIC_AUTH_PASSWORD')}
-    HTTParty.post "#{news_tagger_endpoint}/#{self.id}/assign_entities", basic_auth: auth
+    puts HTTParty.post "#{news_tagger_endpoint}/#{self.id}/assign_entities", basic_auth: auth
   end
 end


### PR DESCRIPTION
We might be encountering a race condition where the NewsItem hasn't been persisted in Postgres before the NewsTagger is trying to tag it - this PR seeks to resolve the issue by only calling the ActiveRecord callback once the NewsItem creation database commit has occurred.