### PR TITLE
Feature/administrate news items export/#695639761657530

### DIFF
--- a/app/controllers/admin/news_items_controller.rb
+++ b/app/controllers/admin/news_items_controller.rb
@@ -10,13 +10,23 @@ module Admin
     def pending
       page = Administrate::Page::Collection.new(dashboard)
       resources = NewsItem.pending.page(params[:page]).per(records_per_page)
-      render :index, locals: { page: page, resources: resources, search_term: search_term, show_search_bar: show_search_bar? }
+      respond_to do |format|
+        format.html {
+          render :index, locals: { page: page, resources: resources, search_term: search_term, show_search_bar: show_search_bar? }
+        }
+        format.csv { send_data NewsItemCsvGenerator.to_csv(NewsItem.pending) }
+      end
     end
 
     def tagged
       page = Administrate::Page::Collection.new(dashboard)
       resources = NewsItem.tagged.page(params[:page]).per(records_per_page)
-      render :index, locals: { page: page, resources: resources, search_term: search_term, show_search_bar: show_search_bar? }
+      respond_to do |format|
+        format.html {
+          render :index, locals: { page: page, resources: resources, search_term: search_term, show_search_bar: show_search_bar? }
+        }
+        format.csv { send_data NewsItemCsvGenerator.to_csv(NewsItem.tagged) }
+      end
     end
 
     private

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -1,7 +1,6 @@
 class NewsItem < ApplicationRecord
-
   belongs_to :feed_source
-  has_one :user # references the Admin user who tagged this NewsItem
+  has_one :user # References the Admin user who tagged this NewsItem
   has_one :news_item_raw
   has_many :mentions, class_name: 'NewsCoinMention'
   has_many :coins, through: :mentions
@@ -18,7 +17,7 @@ class NewsItem < ApplicationRecord
   after_create_commit :notify_news_tagger
 
   def coin_link_data
-    coins.map{ |c| c.as_json(only: [:symbol, :slug] ) }
+    coins.map { |coin| coin.as_json(only: [:symbol, :slug] ) }
   end
 
   def coin_symbols

--- a/lib/news_item_csv_generator.rb
+++ b/lib/news_item_csv_generator.rb
@@ -1,0 +1,17 @@
+class NewsItemCsvGenerator
+  def self.to_csv(news_items, options = {})
+    column_headers = %w[id, coin_symbols, news_categories, user_email, title, created_at]
+    CSV.generate(options) do |csv|
+      news_items.each do |news_item|
+        csv << [
+          news_item.id,
+          news_item.coin_symbols,
+          news_item.news_category_names,
+          news_item.user_id,
+          news_item.title,
+          news_item.created_at,
+        ]
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://app.asana.com/0/683768070860536/695639761657530

Provide Ops with the tools they need to handle manual tagging easier.

This needs to be merged into `master` for usage on the production website where the manual tagging occurs.