### PR TITLE
Disable dblink PG extension installation on Heroku

### DIFF
--- a/db/migrate/20180803121611_add_db_link_extension.rb
+++ b/db/migrate/20180803121611_add_db_link_extension.rb
@@ -1,13 +1,18 @@
 class AddDbLinkExtension < ActiveRecord::Migration[5.1]
   def up
-    execute <<-SQL
-      CREATE extension IF NOT EXISTS dblink;
-    SQL
+    # Heroku already has this extension installed and does not allow for installation.
+    unless Rails.env.production?
+      execute <<-SQL
+        CREATE extension IF NOT EXISTS dblink;
+      SQL
+    end
   end
 
   def down
-    execute <<-SQL
-      DROP extension IF EXISTS dblink;
-    SQL
+    unless Rails.env.production?
+      execute <<-SQL
+        DROP extension IF EXISTS dblink;
+      SQL
+    end
   end
 end


### PR DESCRIPTION
Heroku already has the `dblink` PG extension installed, and does not allow standard database users to install extensions, so we need to modify the database migration to not run on Heroku while still allowing team members to install it locally if they haven't already.