### PR TITLE
Upgrade rubyzip gem to 1.2.2 for security

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,7 +399,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safely_block (0.2.0)
       errbase
     sass (3.5.6)


### PR DESCRIPTION
CVE-2018-1000544
https://nvd.nist.gov/vuln/detail/CVE-2018-1000544