### PR TITLE
Disable Rollbar notification of missing CMC coins

### DIFF
--- a/app/services/coin_market_cap_pro/update_ticker_service.rb
+++ b/app/services/coin_market_cap_pro/update_ticker_service.rb
@@ -29,11 +29,8 @@ module CoinMarketCapPro
 
     def log_db_missing_coins
       @db_missing_coins.sort! { |left, right| left[:ranking] <=> right[:ranking] }
-      @db_missing_coins.each do |update|
-        Rails.logger.info "MISSING COIN: Rank #{update[:ranking]} #{update[:identifier]} coin from CMC is missing from the `coins` table."
-      end
-      unless @db_missing_coins.empty?
-        Rollbar.error('Coins table missing CMC coins', :coins => @db_missing_coins)
+      @db_missing_coins.each do |coin_hash|
+        puts "WARNING - MISSING COIN: Rank #{coin_hash[:ranking]} #{coin_hash[:identifier]} coin from CMC is missing from the `coins` table."
       end
     end
 


### PR DESCRIPTION
Rollbar errors are getting out noisy so figured it's best to remove them.

Switched back to `puts` statement since `Rails.logger` seems to have issues with Papertrail.