### PR TITLE
Add Registration CTA to bottom of all CoinFi News articles

### DIFF
--- a/app/assets/stylesheets/base/general.scss
+++ b/app/assets/stylesheets/base/general.scss
@@ -63,7 +63,6 @@ ol.tips {
   .signup-cta-wrap {
     border: 1px solid rgba(0, 0, 0, 0.12);
     width: 90%;
-    margin: auto;
     h2 {
       border: 0;
     }

--- a/app/javascript/App/bundles/NewsfeedPage/BodySection.tsx
+++ b/app/javascript/App/bundles/NewsfeedPage/BodySection.tsx
@@ -27,6 +27,7 @@ const BodySection = (props: Props) => {
         initialNewsItem={props.initialNewsItem}
         newsItemId={props.newsItemId}
         onCoinClick={props.onCoinClick}
+        loggedIn={props.loggedIn}
       />
     )
   }

--- a/app/javascript/App/bundles/NewsfeedPage/CallToAction.tsx
+++ b/app/javascript/App/bundles/NewsfeedPage/CallToAction.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+
+interface Props {
+  alignLeft?: boolean
+}
+
+export default ({ alignLeft }: Props) => {
+  return (
+    <div className={`ph3 tc signup-cta-wrap ${alignLeft ? '' : 'center'}`}>
+      <h2 className="m0 pv3">Get the most out of CoinFi News!</h2>
+      <div className="f6">
+        Save coins into your Watchlist and be the first to know about the latest
+        market moving news.
+      </div>
+      <button
+        className="btn btn-blue mv3 b ttn"
+        data-heap="news-click-signup-button"
+        onClick={() => (window.location.href = '/register')}
+      >
+        Sign Up Now
+      </button>
+    </div>
+  )
+}

--- a/app/javascript/App/bundles/NewsfeedPage/NewsBody.tsx
+++ b/app/javascript/App/bundles/NewsfeedPage/NewsBody.tsx
@@ -8,6 +8,7 @@ import Icon from '~/bundles/common/components/Icon'
 import localAPI from '../common/utils/localAPI'
 
 import TwitterBody from './TwitterBody'
+import CallToAction from './CallToAction'
 import LoadingIndicator from '../common/components/LoadingIndicator'
 import {
   getDomainType,
@@ -165,6 +166,9 @@ export default class NewsBody extends React.Component<Props, State> {
             }}
           </RailsConsumer>
         </div>
+
+        <br />
+        <CallToAction />
       </div>
     )
   }

--- a/app/javascript/App/bundles/NewsfeedPage/NewsBody.tsx
+++ b/app/javascript/App/bundles/NewsfeedPage/NewsBody.tsx
@@ -22,6 +22,7 @@ import NewsBodyShareButtons from './NewsBodyShareButtons'
 import { RailsConsumer } from '~/bundles/common/contexts/RailsContext'
 
 interface Props {
+  loggedIn: boolean
   initialNewsItem?: NewsItem
   newsItemId?: string
   onCoinClick?: CoinClickHandler
@@ -81,7 +82,11 @@ export default class NewsBody extends React.Component<Props, State> {
 
     if (getDomainType(newsItem.url) === 'twitter') {
       return (
-        <TwitterBody newsItem={newsItem} onCoinClick={this.props.onCoinClick} />
+        <TwitterBody
+          newsItem={newsItem}
+          onCoinClick={this.props.onCoinClick}
+          loggedIn={this.props.loggedIn}
+        />
       )
     }
 
@@ -168,7 +173,7 @@ export default class NewsBody extends React.Component<Props, State> {
         </div>
 
         <br />
-        <CallToAction />
+        {!this.props.loggedIn && <CallToAction />}
       </div>
     )
   }

--- a/app/javascript/App/bundles/NewsfeedPage/Tips.tsx
+++ b/app/javascript/App/bundles/NewsfeedPage/Tips.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import CallToAction from './CallToAction'
 import Icon from '~/bundles/common/components/Icon'
 const chartIcon = require('~/images/chartIcon.svg') // tslint:disable-line
 const filterIcon = require('~/images/filterIcon.svg') // tslint:disable-line
@@ -96,21 +97,7 @@ export default ({ closeTips, loggedIn }: Props) => {
           </ol>
         </div>
 
-        {!loggedIn && (
-          <div className="ph3 tc signup-cta-wrap">
-            <h2 className="m0 pv3">Get the most out of CoinFi News!</h2>
-            <div className="f6">
-              Save coins into your Watchlist and be the first to know about the
-              latest market moving news.
-            </div>
-            <button
-              className="btn btn-blue mv3 b ttn"
-              onClick={() => (window.location.href = '/register')}
-            >
-              Sign Up Now
-            </button>
-          </div>
-        )}
+        {!loggedIn && <CallToAction />}
       </div>
     </div>
   )

--- a/app/javascript/App/bundles/NewsfeedPage/TwitterBody.tsx
+++ b/app/javascript/App/bundles/NewsfeedPage/TwitterBody.tsx
@@ -4,6 +4,7 @@ import CoinTags from '../common/components/CoinTags'
 import { NewsItem } from './types'
 import { getTweetId } from '~/bundles/common/utils/url'
 import { CoinClickHandler } from '../common/types'
+import CallToAction from './CallToAction'
 
 interface Props {
   newsItem: NewsItem
@@ -23,23 +24,26 @@ export default class NewsBody extends React.Component<Props, {}> {
     const categories = newsItem.categories
 
     return (
-      <div className="pa4 bg-white min-h-100">
-        <CoinTags
-          itemWithCoinLinkData={newsItem}
-          getLink={(data) => `/news/${data.slug}`}
-          onClick={this.props.onCoinClick}
-        />
-        {categories.length > 0 && (
-          <div className="mt3">
-            {categories.map((category, index) => (
-              <div key={index} className="tag-alt">
-                {category.name}
-              </div>
-            ))}
-          </div>
-        )}
-        <Tweet tweetId={tweetId} />
-      </div>
+      <>
+        <div className="pa4 bg-white min-h-100">
+          <CoinTags
+            itemWithCoinLinkData={newsItem}
+            getLink={(data) => `/news/${data.slug}`}
+            onClick={this.props.onCoinClick}
+          />
+          {categories.length > 0 && (
+            <div className="mt3">
+              {categories.map((category, index) => (
+                <div key={index} className="tag-alt">
+                  {category.name}
+                </div>
+              ))}
+            </div>
+          )}
+          <Tweet tweetId={tweetId} />
+          <CallToAction alignLeft={true} />
+        </div>
+      </>
     )
   }
 }

--- a/app/javascript/App/bundles/NewsfeedPage/TwitterBody.tsx
+++ b/app/javascript/App/bundles/NewsfeedPage/TwitterBody.tsx
@@ -8,12 +8,13 @@ import CallToAction from './CallToAction'
 
 interface Props {
   newsItem: NewsItem
+  loggedIn: boolean
   onCoinClick?: CoinClickHandler
 }
 
 export default class NewsBody extends React.Component<Props, {}> {
   public render() {
-    const { newsItem } = this.props
+    const { newsItem, loggedIn } = this.props
 
     if (!newsItem) {
       return null
@@ -24,26 +25,24 @@ export default class NewsBody extends React.Component<Props, {}> {
     const categories = newsItem.categories
 
     return (
-      <>
-        <div className="pa4 bg-white min-h-100">
-          <CoinTags
-            itemWithCoinLinkData={newsItem}
-            getLink={(data) => `/news/${data.slug}`}
-            onClick={this.props.onCoinClick}
-          />
-          {categories.length > 0 && (
-            <div className="mt3">
-              {categories.map((category, index) => (
-                <div key={index} className="tag-alt">
-                  {category.name}
-                </div>
-              ))}
-            </div>
-          )}
-          <Tweet tweetId={tweetId} />
-          <CallToAction alignLeft={true} />
-        </div>
-      </>
+      <div className="pa4 bg-white min-h-100">
+        <CoinTags
+          itemWithCoinLinkData={newsItem}
+          getLink={(data) => `/news/${data.slug}`}
+          onClick={this.props.onCoinClick}
+        />
+        {categories.length > 0 && (
+          <div className="mt3">
+            {categories.map((category, index) => (
+              <div key={index} className="tag-alt">
+                {category.name}
+              </div>
+            ))}
+          </div>
+        )}
+        <Tweet tweetId={tweetId} />
+        {!loggedIn && <CallToAction alignLeft={true} />}
+      </div>
     )
   }
 }


### PR DESCRIPTION
https://app.asana.com/0/902343675126966/921631352220749

`alignLeft` is a janky solution I just threw together; the default is to be center aligned, so `alignLeft` is an optional param specifically for Twitter to make the layout look reasonable.

This PR also includes Heap instrumentation.

<img width="2032" alt="screen shot 2018-11-28 at 11 56 23 am" src="https://user-images.githubusercontent.com/637370/49130105-4276b380-f30d-11e8-855b-f56c2ce59feb.png">
<img width="2032" alt="screen shot 2018-11-28 at 12 58 54 pm" src="https://user-images.githubusercontent.com/637370/49130150-6934ea00-f30d-11e8-8ad8-133ccf4c827a.png">

